### PR TITLE
Update fireOnEveryPaint description

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ There is no web API to easily render complex layouts of text and other content i
 
 `drawHTMLElement(element ...)` takes the CTM (current transform matrix) of the canvas into consideration. The image drawn into the canvas is sized to `element`'s [`devicePixelContentBox`](https://web.dev/articles/device-pixel-content-box); element outsize that bounds (including ink and layout overflow) are clipped. The `drawHTMLElement(element, x, y, dwidth, dheight)` variant resizes the image of `element`'s subtree to `dwidth` and `dheight`.
 
-In an addition, a `fireOnEveryPaint` option is added to `ResizeObserverOptions`, allowing script to be notified whenever elements under a `<canvas>` may render differently, so they can be redrawn. The callback to the resize obsever will be called at resize obsever timing, which is after DOM style and layout, but before paint.
+In an addition, a `fireOnEveryPaint` option is added to `ResizeObserverOptions`, allowing script to be notified whenever any descendants of a `<canvas>` may render differently, so they can be redrawn. The callback to the resize observer will be called at resize observer timing, which is after DOM style and layout, but before paint.
 
 The same element may be drawn multiple times.
 


### PR DESCRIPTION
The key change is that the callback is fired when elements under the canvas may render differently, which includes aspects such as blinking cursors, css animations, etc.