### PR TITLE
Rename drawHTMLElement -> drawHTML

### DIFF
--- a/Examples/complex-text.html
+++ b/Examples/complex-text.html
@@ -42,8 +42,8 @@
       ctx.reset();
       ctx.rotate((45 * Math.PI) / 180);
       ctx.translate(200, -125);
-      if (typeof ctx.drawHTMLElement === "function") {
-        ctx.drawHTMLElement(drawElement, 30, 0);
+      if (typeof ctx.drawHTML === "function") {
+        ctx.drawHTML(drawElement, 30, 0);
       } else {
         ctx.drawElement(drawElement, 30, 0);
       }

--- a/Examples/text-input.html
+++ b/Examples/text-input.html
@@ -20,8 +20,8 @@
     ctx.reset();
     let x = 30 * devicePixelRatio;
     let y = 30 * devicePixelRatio;
-    if (typeof ctx.drawHTMLElement === "function") {
-      ctx.drawHTMLElement(drawElement, x, y);
+    if (typeof ctx.drawHTML === "function") {
+      ctx.drawHTML(drawElement, x, y);
     } else {
       ctx.drawElement(drawElement, x, y);
     }

--- a/Examples/webGL.html
+++ b/Examples/webGL.html
@@ -73,9 +73,9 @@
       const srcFormat = gl.RGBA;
       const srcType = gl.UNSIGNED_BYTE;
 
-      if (typeof gl.texHTMLElement2D === "function") {
-        gl.texHTMLElement2D(gl.TEXTURE_2D, level, internalFormat,
-                            srcFormat, srcType, drawElement);
+      if (typeof gl.texHTML2D === "function") {
+        gl.texHTML2D(gl.TEXTURE_2D, level, internalFormat,
+                     srcFormat, srcType, drawElement);
       } else {
         gl.texElement2D(gl.TEXTURE_2D, level, internalFormat,
                         srcFormat, srcType, drawElement);

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ There is no web API to easily render complex layouts of text and other content i
 * **Composing HTML Elements with Shaders.** A limited set of CSS shaders, such as filter effects, are already available, but there is a desire to use general WebGL shaders with HTML.
 * **HTML Rendering in a 3D Context.** 3D aspects of sites and games need to render rich 2D content into surfaces within a 3D scene.
 
-## Proposed solution: `layoutsubtree`, `drawHTMLElement`, `texHTMLElement2D` and `setHitTestRegions`
+## Proposed solution: `layoutsubtree`, `drawHTML`, `texHTML2D` and `setHitTestRegions`
 
 * The `layoutsubtree` attribute on a `<canvas>` element allows its descendant elements to have layout (*), and causes the direct children of the `<canvas>` to have a stacking context and become a containing block for all descendants. Descendant elements of the `<canvas>` still do not paint or hit-test, and are not discovered by UA algorithms like find-in-page.
-* The `CanvasRenderingContext2D.drawHTMLElement(element, x, y)` method renders `element` and its subtree into a 2D canvas at offset x and y, so long as `element` is a direct child of the `<canvas>`. It has no effect if `layoutsubtree` is not specified on the `<canvas>`.
-* The `WebGLRenderingContext.texHTMLElement2D(..., element)` method renders `element` into a WebGL texture. It has no effect if `layoutsubtree` is not specified on the `<canvas>`.
+* The `CanvasRenderingContext2D.drawHTML(element, x, y)` method renders `element` and its subtree into a 2D canvas at offset x and y, so long as `element` is a direct child of the `<canvas>`. It has no effect if `layoutsubtree` is not specified on the `<canvas>`.
+* The `WebGLRenderingContext.texHTML2D(..., element)` method renders `element` into a WebGL texture. It has no effect if `layoutsubtree` is not specified on the `<canvas>`.
 * The `CanvasRenderingContext2D.setHitTestRegions([{element: ., rect: {x: x, y: y, width: ..., height: ...}, ...])` (and `WebGLRenderingContext.setHitTestRegions(...)`) API takes a list of elements and `<canvas>`-relative rects indicating where the element paints relative to the backing buffer of the canvas. These rects are then used to redirect hit tests for mouse and touch events automatically from the `<canvas>` element to the drawn element.
 
 (*) Without `layoutsubtree`, geometry APIs such as `getBoundingClientRect()` on these elements return an empty rect. They do have computed styles, however, and are keyboard-focusable.
 
-`drawHTMLElement(element ...)` takes the CTM (current transform matrix) of the canvas into consideration. The image drawn into the canvas is sized to `element`'s [`devicePixelContentBox`](https://web.dev/articles/device-pixel-content-box); content outside those bounds (including ink and layout overflow) are clipped. The `drawHTMLElement(element, x, y, dwidth, dheight)` variant resizes the image of `element`'s subtree to `dwidth` and `dheight`.
+`drawHTML(element ...)` takes the CTM (current transform matrix) of the canvas into consideration. The image drawn into the canvas is sized to `element`'s [`devicePixelContentBox`](https://web.dev/articles/device-pixel-content-box); content outside those bounds (including ink and layout overflow) are clipped. The `drawHTML(element, x, y, dwidth, dheight)` variant resizes the image of `element`'s subtree to `dwidth` and `dheight`.
 
 In addition, a `fireOnEveryPaint` option is added to `ResizeObserverOptions`, allowing script to be notified whenever any descendants of a `<canvas>` may render differently, so they can be redrawn. The callback to the resize observer will be called at resize observer timing, which is after DOM style and layout, but before paint.
 
@@ -51,10 +51,10 @@ interface CanvasRenderingContext2D {
   ...
 
   [RaisesException]
-  void drawHTMLElement(Element element, unrestricted double x, unrestricted double y);
+  void drawHTML(Element element, unrestricted double x, unrestricted double y);
 
   [RaisesException]
-  void drawHTMLElement(Element element, unrestricted double x, unrestricted double y,
+  void drawHTML(Element element, unrestricted double x, unrestricted double y,
                        unrestricted double dwidth, unrestricted double dheight);
 
 ```
@@ -65,18 +65,18 @@ interface WebGLRenderingContext {
   ...
 
   [RaisesException]
-    void texHTMLElement2D(GLenum target, GLint level, GLint internalformat,
+    void texHTML2D(GLenum target, GLint level, GLint internalformat,
                           GLenum format, GLenum type, Element element);
 
 ```
 
 ## Demos
 
-#### [See here](Examples/complex-text.html) to see an example of how to use the API. It should render like the following (the blue rectangle indicates the bounds of the `<canvas>`, and the black the element passed to drawHTMLElement). It draws like this:
+#### [See here](Examples/complex-text.html) to see an example of how to use the API. It should render like the following (the blue rectangle indicates the bounds of the `<canvas>`, and the black the element passed to drawHTML). It draws like this:
 
 ![image](https://github.com/user-attachments/assets/88d5200b-176c-4102-a4a0-f5893101b295)
 
-#### [See here](Examples/webGL.html) for an example of how to use the WebGL `texHTMLElement2D` API to populate a GL texture with HTML content.
+#### [See here](Examples/webGL.html) for an example of how to use the WebGL `texHTML2D` API to populate a GL texture with HTML content.
 The example should render an animated cube, like in the following snapshot. Note how the border box fills the entire face of the cube.
 To adjust that, modify the texture coordinates for rendering the cube and possibly adjust the texture wrap
 parameters. Or, wrap the content in a larger `<div>` and draw the `<div>`.  It draws like this:
@@ -94,10 +94,10 @@ are [here](https://github.com/mrdoob/three.js/pull/31233).
 The HTML-in-Canvas features may be enabled by passing the `--enable-blink-features=CanvasDrawElement` to Chrome Canary versions later than 138.0.7175.0.
 
 Notes for dev trial usage:
-* The methods were recently renamed: `drawHTMLElement` was previously `drawElement` and `texHTMLElement2D` was formerly `texElement2D`. The rename will land shortly in Chrome Canary. The change was made at developers' request to avoid confusion with existing WebGL methods. The old names will continue to work until at least Chrome 145.
+* The methods were recently renamed: `drawHTML` was previously `drawElement` and `texHTML2D` was formerly `texElement2D`. The rename will land shortly in Chrome Canary. The change was made at developers' request to avoid confusion with existing WebGL methods. The old names will continue to work until at least Chrome 145.
 * The features are currently under active development and changes to the API may happen at any time, though we make every effort to avoid unnecessary churn.
 * Not all personal information (PII) is currently prevented from being painted, so take extreme care to avoid leaking PII in any demos.
-* The space of possible HTML content is enormous and only a tiny fraction has been tested with `drawHTMLElement`.
+* The space of possible HTML content is enormous and only a tiny fraction has been tested with `drawHTML`.
 * Interactive elements (such as links, forms or buttons) can be drawn into the canvas, but are not automatically interactive.
 
 Other known limitations:


### PR DESCRIPTION
Followup to https://github.com/WICG/html-in-canvas/pull/35 to further rename the API to be shorter and reduce ambiguity around SVG elements (which are supported). See: https://github.com/WICG/html-in-canvas/issues/32.