### PR TITLE
docs: improve README accessibility with semantic HTML elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ The transform used to draw the element on the worker thread needs to be synced b
 
 ```html
 <canvas id="canvas" style="width: 200px; height: 200px;" layoutsubtree>
-  <div id="form_element">
-    name: <input>
-  </div>
+  <form id="form_element">
+    <label for="name">name:</label>
+    <input id="name">
+  </form>
 </canvas>
 
 <script>
@@ -106,7 +107,7 @@ In this example, `OffscreenCanvas` in a worker is used. The `canvas` child eleme
 ```html
 <!DOCTYPE html>
 <canvas id="canvas" style="width: 300px; height: 200px;" layoutsubtree>
-  <div id="label">enter your fullname:</div>
+  <label id="label" for="input">enter your fullname:</label>
   <input id="input">
 </canvas>
 


### PR DESCRIPTION
Description
Improves README accessibility by replacing generic `<div>` containers with semantic `<form>` and `<label>` elements in example snippets. This ensures better screen reader support and follows best practices for interactive content.

Changes
- Updated "Basic Example" and "OffscreenCanvas Example" with semantic HTML.
- Added for attributes to correctly link labels and inputs. Now clicking on label can help us focus into the input.