### PR TITLE
tweak syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The APIs described here are implemented behind a flag in Chromium and can be ena
 
 ## Motivation
 
-There is no web API to easily render complex layouts of text and other content into a `<canvas>`. As a result, `<canvas>`-based content suffers in accessibility, internationalization, performance, and quality.
+There is no web API to easily render complex layouts of text and other content in a `<canvas>`. As a result, `<canvas>`-based content suffers in accessibility, internationalization, performance, and quality.
 
 ### Use cases
 


### PR DESCRIPTION
The preposition "into" generally implies transformation or transportation:

- the witch turned him _into_ a frog
- the bar tender carefully poured beer _into_ my chilled glass

I see neither of those, so I assume "in" was intended.