### PR TITLE
Rename PaintEvent to CanvasPaintEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,13 +273,13 @@ partial interface GPUQueue {
 }
 
 [Exposed=Window]
-interface PaintEvent : Event {
-  constructor(DOMString type, optional PaintEventInit eventInitDict);
+interface CanvasPaintEvent : Event {
+  constructor(DOMString type, optional CanvasPaintEventInit eventInitDict);
 
   [SameObject] readonly attribute FrozenArray<Element> changedElements;
 };
 
-dictionary PaintEventInit : EventInit {
+dictionary CanvasPaintEventInit : EventInit {
   sequence<Element> changedElements = [];
 };
 

--- a/README.md
+++ b/README.md
@@ -235,13 +235,13 @@ partial interface GPUQueue {
 }
 
 [Exposed=Window]
-interface PaintEvent : Event {
-  constructor(DOMString type, optional PaintEventInit eventInitDict);
+interface CanvasPaintEvent : Event {
+  constructor(DOMString type, optional CanvasPaintEventInit eventInitDict);
 
   readonly attribute FrozenArray<Element> changedElements;
 };
 
-dictionary PaintEventInit : EventInit {
+dictionary CanvasPaintEventInit : EventInit {
   sequence<Element> changedElements = [];
 };
 


### PR DESCRIPTION
Change PaintEvent to CanvasPaintEvent in README.md.

It's a bit odd in that git says foolip did this already, but who knows.

Also, all the code, including the idl, already uses CanvasPaintEvent so no code changes are needed.